### PR TITLE
Add functionality to crash on start non-existing directory

### DIFF
--- a/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
+++ b/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
@@ -45,11 +45,8 @@ object Generate extends ToolCommand[Args] {
 
     logger.info("Start")
 
-    if (!cmdArgs.outputDir.exists()) {
-      cmdArgs.outputDir.mkdirs()
-      logger.warn(s"Output directory does not exist.")
-      logger.warn(s"Creating output directory: ${cmdArgs.outputDir.getAbsolutePath}")
-    }
+    require(cmdArgs.outputDir.exists(), s"Output directory does not exist: ${cmdArgs.outputDir.getPath}")
+    require(cmdArgs.outputDir.isDirectory, s"'${cmdArgs.outputDir.getPath}' is not a directory!")
 
     val sequenceDict: SAMSequenceDictionary =
       cmdArgs.referenceFasta match {

--- a/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
+++ b/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
@@ -45,8 +45,10 @@ object Generate extends ToolCommand[Args] {
 
     logger.info("Start")
 
-    require(cmdArgs.outputDir.exists(), s"Output directory does not exist: ${cmdArgs.outputDir.getPath}")
-    require(cmdArgs.outputDir.isDirectory, s"'${cmdArgs.outputDir.getPath}' is not a directory!")
+    require(cmdArgs.outputDir.exists(),
+            s"Output directory does not exist: ${cmdArgs.outputDir.getPath}")
+    require(cmdArgs.outputDir.isDirectory,
+            s"'${cmdArgs.outputDir.getPath}' is not a directory!")
 
     val sequenceDict: SAMSequenceDictionary =
       cmdArgs.referenceFasta match {

--- a/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
+++ b/src/main/scala/nl/biopet/tools/bamstats/generate/Generate.scala
@@ -45,6 +45,12 @@ object Generate extends ToolCommand[Args] {
 
     logger.info("Start")
 
+    if (!cmdArgs.outputDir.exists()) {
+      cmdArgs.outputDir.mkdirs()
+      logger.warn(s"Output directory does not exist.")
+      logger.warn(s"Creating output directory: ${cmdArgs.outputDir.getAbsolutePath}")
+    }
+
     val sequenceDict: SAMSequenceDictionary =
       cmdArgs.referenceFasta match {
         case Some(reference) =>

--- a/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
+++ b/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
@@ -45,6 +45,20 @@ class GenerateTest extends ToolTest[Args] {
   }
 
   @Test
+  def testDirCreation: Unit = {
+    val outputDir = Files.createTempDir()
+    outputDir.delete()
+    outputDir.exists() shouldBe false
+    Generate.main(
+      Array("-b", pairedBam01.getAbsolutePath, "-o", outputDir.getAbsolutePath))
+
+    val bamstatsFile = new File(outputDir, "bamstats.json")
+    bamstatsFile should exist
+    val bamstatsSummaryFile = new File(outputDir, "bamstats.summary.json")
+    bamstatsSummaryFile should exist
+  }
+
+  @Test
   def testMain(): Unit = {
     val outputDir = Files.createTempDir()
     outputDir.deleteOnExit()

--- a/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
+++ b/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
@@ -45,17 +45,27 @@ class GenerateTest extends ToolTest[Args] {
   }
 
   @Test
-  def testDirCreation: Unit = {
+  def testDirError(): Unit = {
     val outputDir = Files.createTempDir()
     outputDir.delete()
     outputDir.exists() shouldBe false
-    Generate.main(
-      Array("-b", pairedBam01.getAbsolutePath, "-o", outputDir.getAbsolutePath))
-
-    val bamstatsFile = new File(outputDir, "bamstats.json")
-    bamstatsFile should exist
-    val bamstatsSummaryFile = new File(outputDir, "bamstats.summary.json")
-    bamstatsSummaryFile should exist
+    intercept[IllegalArgumentException] {
+      Generate.main(
+        Array("-b",
+              pairedBam01.getAbsolutePath,
+              "-o",
+              outputDir.getAbsolutePath))
+    }.getMessage shouldBe s"Output dir does not exist: ${outputDir.getAbsolutePath}"
+    outputDir.createNewFile()
+    outputDir.exists() shouldBe true
+    outputDir.isFile shouldBe true
+    intercept[IllegalArgumentException] {
+      Generate.main(
+        Array("-b",
+              pairedBam01.getAbsolutePath,
+              "-o",
+              outputDir.getAbsolutePath))
+    }.getMessage shouldBe s"'${outputDir.getAbsolutePath}' is not a directory!"
   }
 
   @Test

--- a/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
+++ b/src/test/scala/nl/biopet/tools/bamstats/generate/GenerateTest.scala
@@ -55,7 +55,8 @@ class GenerateTest extends ToolTest[Args] {
               pairedBam01.getAbsolutePath,
               "-o",
               outputDir.getAbsolutePath))
-    }.getMessage shouldBe s"Output dir does not exist: ${outputDir.getAbsolutePath}"
+    }.getMessage should include(
+      s"Output directory does not exist: ${outputDir.getAbsolutePath}")
     outputDir.createNewFile()
     outputDir.exists() shouldBe true
     outputDir.isFile shouldBe true
@@ -65,7 +66,8 @@ class GenerateTest extends ToolTest[Args] {
               pairedBam01.getAbsolutePath,
               "-o",
               outputDir.getAbsolutePath))
-    }.getMessage shouldBe s"'${outputDir.getAbsolutePath}' is not a directory!"
+    }.getMessage should include(
+      s"'${outputDir.getAbsolutePath}' is not a directory!")
   }
 
   @Test


### PR DESCRIPTION
### Description

Instead of crashing at the very end of the analysis because the file is not there... Which is the current behaviour.
----

### Checklist (never delete this)

- [x] Each method/class/object/trait should have scaladocs
- [x] Added methods are unit tested
- [x] Test coverage may not drop
- [x] Documentation should be updated if required
